### PR TITLE
Minecraft Wiki has moved

### DIFF
--- a/src/main/java/com/anthonyhilyard/wikilookup/WikiLookupConfig.java
+++ b/src/main/java/com/anthonyhilyard/wikilookup/WikiLookupConfig.java
@@ -20,7 +20,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 public class WikiLookupConfig extends IcebergConfig<WikiLookupConfig>
 {
-	private static final String MINECRAFT_WIKI_URL = "https://minecraft.fandom.com/wiki/Special:Search?go=Search&search={}";
+	private static final String MINECRAFT_WIKI_URL = "https://minecraft.wiki/w/Special:Search?search={}";
 	private static WikiLookupConfig INSTANCE;
 	public static WikiLookupConfig getInstance() { return INSTANCE; }
 


### PR DESCRIPTION
Updated the URL as the Minecraft Wiki has moved to **https://minecraft.wiki/**.

See also the announcement at https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom